### PR TITLE
Prettier2

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,10 +6,8 @@ module.exports = {
     node: true,
     mocha: true,
   },
-  extends: [
-    'airbnb-base', 'prettier'
-  ],
-  plugins: ['prettier', ],
+  extends: ['airbnb-base', 'prettier'],
+  plugins: ['prettier'],
   globals: {
     Atomics: 'readonly',
     SharedArrayBuffer: 'readonly',
@@ -18,10 +16,22 @@ module.exports = {
     ecmaVersion: 2018,
   },
   rules: {
-    "prettier/prettier": ["error", { singleQuote: true, trailingComma: "all" }],
-    curly: ["error", "all"],
-    "require-await": "error",
-    "no-trailing-spaces": ["error"],
-    "default-param-last": ["error"],
+    'prettier/prettier': [
+      'error',
+      { singleQuote: true, trailingComma: 'all' },
+    ],
+    curly: ['error', 'all'],
+    'require-await': 'error',
+    'no-trailing-spaces': ['error'],
+    'default-param-last': ['error'],
+    'quote-props': ["error", 'as-needed'],
   },
+  overrides: [
+    {
+      files: ['examples/**/*.js'],
+      rules: {
+        'no-console': 'off',
+      },
+    },
+  ],
 };

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "arrowParens": "avoid",
+  "quoteProps": "as-needed"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8590,9 +8590,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.4.tgz",
+      "integrity": "sha512-SVJIQ51spzFDvh4fIbCLvciiDMCrRhlN3mbZvv/+ycjvmF5E73bKdGfU8QDLNmjYJf+lsGnDBC4UUnvTe5OO0w==",
       "dev": true
     },
     "prettier-eslint": {
@@ -8852,6 +8852,12 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
           "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "dev": true
+        },
+        "prettier": {
+          "version": "1.19.1",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+          "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
           "dev": true
         },
         "progress": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-tools",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "mocha": "^7.1.1",
     "npm-run-all": "^4.1.5",
     "nyc": "^15.0.1",
-    "prettier": "^1.19.1",
+    "prettier": "^2.0.4",
     "prettier-eslint": "^9.0.1",
     "rimraf": "^3.0.2",
     "run-sequence": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-tools",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Various tools for using and integrating with Swagger.",
   "main": "src/index.js",
   "scripts": {

--- a/src/middleware/swagger-validator.js
+++ b/src/middleware/swagger-validator.js
@@ -83,10 +83,7 @@ const send400 = (req, res, next, origErr) => {
           err.code === 'INVALID_TYPE' &&
           err.message.split(' ')[0] === 'Value'
         ) {
-          validationMessage += err.message
-            .split(' ')
-            .slice(1)
-            .join(' ');
+          validationMessage += err.message.split(' ').slice(1).join(' ');
         } else {
           validationMessage += `is ${err.message
             .charAt(0)
@@ -99,10 +96,7 @@ const send400 = (req, res, next, origErr) => {
       case 'ARRAY_LENGTH_SHORT':
       case 'MAX_LENGTH':
       case 'MIN_LENGTH':
-        validationMessage += err.message
-          .split(' ')
-          .slice(1)
-          .join(' ');
+        validationMessage += err.message.split(' ').slice(1).join(' ');
 
         break;
 


### PR DESCRIPTION
This updates the prettier package to cover some advisories experienced with the original version. Has quite a bit different in terms of "opinions" this time around... plus it doesn't seem to handle parsing as well, multi-line statements kind of confused it, particularly with it's "allowParens" rule.

Updated linting where applicable to keep it neat and sweet.